### PR TITLE
Fix BeamNG LiDAR vehicle mounting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install python-dotenv tqdm "gymnasium[toy-text]==1.0.0" numpy matplotlib pygame pytest
+          pip install python-dotenv tqdm "gymnasium[toy-text]==1.0.0" numpy matplotlib pygame pytest beamngpy
           pip install torch --index-url https://download.pytorch.org/whl/cpu
 
       - name: Smoke test - imports & registry

--- a/core/cli.py
+++ b/core/cli.py
@@ -313,7 +313,7 @@ def _human_play_menu():
             env.human_play()
     finally:
         if env is not None:
-            env.close()
+            env.close(kill_sim=False)
 
 
 def _trajectory_menu():

--- a/docs/beamng_environment.md
+++ b/docs/beamng_environment.md
@@ -116,7 +116,7 @@ The agent spawns at `(61, −788, 101)` facing north.
 | Channels per ray | 1 (distance). Extensible via `LIDAR_CHANNELS_PER_RAY`. |
 | Field of view | 120° (forward-facing, ±60°) |
 | Max range | 50 m |
-| Mount position | (0, −1.8, 1.15) — forward of bumper, hood-line height |
+| Mount position | Seeded just above the bbox roof from `vehicle.get_bbox()`, then BeamNG LiDAR `is_snapping_desired=True` + `is_force_inside_triangle=True` snaps it onto the nearest vehicle surface. Falls back to `(0, −1.8, 1.15)` if bbox sampling fails. |
 | Direction | forward (0, −1, 0) in BeamNG coords |
 | Vertical angle | 6° |
 | Vertical resolution | 16 layers |
@@ -148,9 +148,9 @@ step(action_idx)
   └─ _compute_reward() — compute reward + done flag
   └─ returns (obs, reward, done, info)
 
-close()
+close(kill_sim=True)
   └─ lidar.remove()
-  └─ bng.close()
+  └─ bng.close() when kill_sim=True, bng.disconnect() when kill_sim=False
 ```
 
 ---

--- a/environments/beamng.py
+++ b/environments/beamng.py
@@ -314,19 +314,30 @@ class BeamNGDrivingEnv:
         except KeyboardInterrupt:
             print("[BeamNGDrivingEnv] Human play stopped.")
 
-    def close(self):
-        """Shut down the BeamNG connection."""
+    def close(self, kill_sim: bool = True):
+        """Close this environment.
+
+        BeamNGpy `close()` kills the BeamNG process by default. Human-play uses
+        `kill_sim=False` so returning to the menu or switching options only
+        disconnects this client and leaves the already-open game running.
+        """
         if self.bng is not None:
-            if self.lidar is not None:
-                t = threading.Thread(target=self.lidar.remove, daemon=True)
-                t.start()
-                t.join(timeout=3.0)
-                self.lidar = None
-            t = threading.Thread(target=self.bng.close, daemon=True)
+            self._remove_lidar()
+            close_fn = self.bng.close if kill_sim else self.bng.disconnect
+            t = threading.Thread(target=close_fn, daemon=True)
             t.start()
             t.join(timeout=5.0)
             self.bng = None
             self.vehicle = None
+
+    def _remove_lidar(self):
+        """Detach the current LiDAR before replacing the ego vehicle/scenario."""
+        if self.lidar is None:
+            return
+        t = threading.Thread(target=self.lidar.remove, daemon=True)
+        t.start()
+        t.join(timeout=3.0)
+        self.lidar = None
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -370,6 +381,11 @@ class BeamNGDrivingEnv:
 
     def _load_scenario(self, human_control=False):
         # self._randomize_waypoints()
+        # A LiDAR is bound to the current BeamNG vehicle. Remove it before
+        # replacing `self.vehicle` so changing vehicle/model cannot leave a
+        # stale sensor attached to the previous ego.
+        self._remove_lidar()
+        self._ego_local_extents = None
         self.scenario = Scenario(
             self.map_name,
             "rl_driving",
@@ -400,29 +416,16 @@ class BeamNGDrivingEnv:
         self.bng.start_scenario()
         time.sleep(1.0)  # let the game settle before polling
 
-        # Lidar must be created after the scenario starts (it communicates with the sim directly)
-        if self.lidar is not None:
-            self.lidar.remove()
+        self._cache_ego_local_bbox()
+
+        # Lidar must be created after the scenario starts (it communicates with the sim directly).
         self.lidar = Lidar(
             "lidar",
             self.bng,
             self.vehicle,
-            pos=self.LIDAR_MOUNT_POS,
-            dir=self.LIDAR_MOUNT_DIR,
-            up=self.LIDAR_MOUNT_UP,
-            requested_update_time=0.05,  # ~2 sensor updates per env step
-            frequency=30,  # aligned with set_deterministic(30)
-            vertical_resolution=self.LIDAR_VERT_RES,
-            vertical_angle=self.LIDAR_VERT_ANGLE,
-            horizontal_angle=self.LIDAR_FOV_DEG,
-            max_distance=self.LIDAR_MAX_DIST,
-            is_360_mode=False,
-            is_rotate_mode=False,
-            is_using_shared_memory=False,
-            is_visualised=LIDAR_VISUALISE,  # off for training; LIDAR_VISUALISE=true to debug
+            **self._lidar_creation_kwargs(),
         )
 
-        self._cache_ego_local_bbox()
 
         # Draw the initial active-waypoint marker
         self._update_active_marker(0)
@@ -525,6 +528,42 @@ class BeamNGDrivingEnv:
             float(lz.min() - m),
             float(lz.max() + m),
         )
+
+    def _resolve_lidar_mount_pos(self) -> tuple[float, float, float]:
+        """Return a vehicle-local LiDAR seed near the roof for BeamNG snapping.
+
+        BeamNG's LiDAR supports `is_snapping_desired`: the simulator moves the
+        requested vehicle-space `pos` to the nearest vehicle triangle. The seed
+        should therefore be close to the desired surface, not outside the front
+        bbox. A point just above the bbox roof lets BeamNG pick the actual roof
+        triangle for cars with different lengths and heights. If bbox sampling
+        failed, keep the configured fallback rather than guessing.
+        """
+        if self._ego_local_extents is None:
+            return self.LIDAR_MOUNT_POS
+
+        _, _, _, _, _, z_max = self._ego_local_extents
+        return (0.0, 0.0, float(z_max + self.LIDAR_SELF_MARGIN))
+
+    def _lidar_creation_kwargs(self) -> dict:
+        """Return BeamNGpy LiDAR kwargs shared by scenario creation and tests."""
+        return {
+            "pos": self._resolve_lidar_mount_pos(),
+            "dir": self.LIDAR_MOUNT_DIR,
+            "up": self.LIDAR_MOUNT_UP,
+            "requested_update_time": 0.05,  # ~2 sensor updates per env step
+            "frequency": 30,  # aligned with set_deterministic(30)
+            "vertical_resolution": self.LIDAR_VERT_RES,
+            "vertical_angle": self.LIDAR_VERT_ANGLE,
+            "horizontal_angle": self.LIDAR_FOV_DEG,
+            "max_distance": self.LIDAR_MAX_DIST,
+            "is_360_mode": False,
+            "is_rotate_mode": False,
+            "is_using_shared_memory": False,
+            "is_visualised": LIDAR_VISUALISE,  # off for training; LIDAR_VISUALISE=true to debug
+            "is_snapping_desired": True,
+            "is_force_inside_triangle": True,
+        }
 
     def _lidar_keep_mask(self, local_x, local_y, local_z) -> np.ndarray:
         """Reject points that are (a) inside the ego OBB or (b) ground returns.

--- a/environments/beamng.py
+++ b/environments/beamng.py
@@ -426,7 +426,6 @@ class BeamNGDrivingEnv:
             **self._lidar_creation_kwargs(),
         )
 
-
         # Draw the initial active-waypoint marker
         self._update_active_marker(0)
 

--- a/tests/test_beamng_lidar.py
+++ b/tests/test_beamng_lidar.py
@@ -1,0 +1,96 @@
+"""Unit tests for BeamNG LiDAR geometry helpers."""
+
+import pytest
+
+from environments.beamng import BeamNGDrivingEnv
+
+
+def _env_with_extents(extents):
+    env = BeamNGDrivingEnv.__new__(BeamNGDrivingEnv)
+    env._ego_local_extents = extents
+    return env
+
+
+class _FakeLidar:
+    def __init__(self):
+        self.removed = False
+
+    def remove(self):
+        self.removed = True
+
+
+class _FakeBeamNG:
+    def __init__(self):
+        self.closed = False
+        self.disconnected = False
+
+    def close(self):
+        self.closed = True
+
+    def disconnect(self):
+        self.disconnected = True
+
+
+def test_lidar_mount_starts_above_cached_vehicle_bbox_for_beamng_snapping():
+    env = _env_with_extents((-4.0, 6.0, -1.4, 1.4, 0.2, 3.8))
+
+    mount_x, mount_y, mount_z = env._resolve_lidar_mount_pos()
+
+    assert mount_x == pytest.approx(0.0)
+    assert mount_y == pytest.approx(0.0)
+    assert mount_z > 3.8
+
+
+def test_lidar_mount_scales_roof_seed_with_small_vehicle_bbox():
+    env = _env_with_extents((-1.1, 1.0, -0.45, 0.45, 0.1, 1.3))
+
+    mount_x, mount_y, mount_z = env._resolve_lidar_mount_pos()
+
+    assert mount_x == pytest.approx(0.0)
+    assert mount_y == pytest.approx(0.0)
+    assert mount_z == pytest.approx(1.3 + BeamNGDrivingEnv.LIDAR_SELF_MARGIN)
+
+
+def test_lidar_mount_keeps_configured_fallback_without_cached_bbox():
+    env = _env_with_extents(None)
+
+    assert env._resolve_lidar_mount_pos() == BeamNGDrivingEnv.LIDAR_MOUNT_POS
+
+
+def test_lidar_creation_uses_beamng_surface_snapping():
+    env = _env_with_extents((-4.0, 6.0, -1.4, 1.4, 0.2, 3.8))
+
+    kwargs = env._lidar_creation_kwargs()
+
+    assert kwargs["pos"] == env._resolve_lidar_mount_pos()
+    assert kwargs["is_snapping_desired"] is True
+    assert kwargs["is_force_inside_triangle"] is True
+
+
+def test_remove_lidar_detaches_current_sensor_before_vehicle_replacement():
+    env = _env_with_extents(None)
+    lidar = _FakeLidar()
+    env.lidar = lidar
+
+    env._remove_lidar()
+
+    assert lidar.removed is True
+    assert env.lidar is None
+
+
+def test_close_can_disconnect_without_killing_human_play_simulator():
+    env = _env_with_extents(None)
+    lidar = _FakeLidar()
+    env.lidar = lidar
+    bng = _FakeBeamNG()
+    env.bng = bng
+    env.vehicle = object()
+
+    env.close(kill_sim=False)
+    assert lidar.removed is True
+    assert env.lidar is None
+
+    assert bng.disconnected is True
+    assert bng.closed is False
+    assert env.bng is None
+    assert env.vehicle is None


### PR DESCRIPTION
## Summary
- Reworked BeamNG LiDAR mounting so the sensor is seeded above the current vehicle bbox and BeamNG snaps it to the nearest vehicle surface with `is_snapping_desired=True` and `is_force_inside_triangle=True`.
- Refetched/removes the LiDAR when the BeamNG vehicle/scenario is replaced, so changing vehicles does not leave a stale sensor attached to the previous ego vehicle.
- Updated human play shutdown to disconnect BeamNGpy without killing the running BeamNG process, and documented the LiDAR lifecycle.
- Added regression tests covering LiDAR mount seed selection, BeamNG snapping flags, LiDAR removal, and non-killing human-play close behavior.

## Notes
- BeamNG/BeamNGpy does not expose an `ignore_own_vehicle` LiDAR option in the docs/examples. The point cloud is raw, so ego/ground filtering remains handled in `BeamNGDrivingEnv._process_lidar()`.
- Debug logs like `self > 0`, `kept = 0`, `bins = 1.00` mean ego/ground points were filtered and no obstacle was kept.

## Verification
- `ruff check environments/beamng.py core/cli.py tests/test_beamng_lidar.py`
- `pytest`